### PR TITLE
refactor: redesign UI with ChatGPT style

### DIFF
--- a/root/index.html
+++ b/root/index.html
@@ -8,8 +8,8 @@
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
-<body class="bg-[#f7f7f8]">
-  <div id="root" class="min-h-screen p-4"></div>
+<body class="h-screen bg-[#343541] text-gray-100">
+  <div id="root" class="h-full"></div>
   <script type="text/babel">
     const { useState } = React;
 
@@ -67,6 +67,19 @@
       meituan: 'https://www.meituan.com/favicon.ico'
     };
 
+    function Modal({ children, onClose }) {
+      return (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-10">
+          <div className="bg-[#343541] w-full max-w-lg rounded-lg shadow-xl p-6">
+            <div className="flex justify-end">
+              <button onClick={onClose} className="text-gray-400 hover:text-gray-200">✖</button>
+            </div>
+            {children}
+          </div>
+        </div>
+      );
+    }
+
     function TravelForm({ onAdd }) {
       const initialState = {
         type: '出发地',
@@ -78,27 +91,11 @@
       };
       const [form, setForm] = useState(initialState);
 
-      const handleChange = (field, value) => {
-        setForm(prev => ({ ...prev, [field]: value }));
-      };
-
-      const handleLinkChange = (key, value) => {
-        setForm(prev => ({ ...prev, links: { ...prev.links, [key]: value } }));
-      };
-
-      const handleFieldChange = (key, value) => {
-        setForm(prev => ({ ...prev, fields: { ...prev.fields, [key]: value } }));
-      };
-
-      const handleTypeChange = e => {
-        const newType = e.target.value;
-        setForm({ ...initialState, type: newType });
-      };
-
-      const handleTravelModeChange = e => {
-        const mode = e.target.value;
-        setForm(prev => ({ ...prev, travelMode: mode, fields: {} }));
-      };
+      const handleChange = (field, value) => setForm(prev => ({ ...prev, [field]: value }));
+      const handleLinkChange = (key, value) => setForm(prev => ({ ...prev, links: { ...prev.links, [key]: value } }));
+      const handleFieldChange = (key, value) => setForm(prev => ({ ...prev, fields: { ...prev.fields, [key]: value } }));
+      const handleTypeChange = e => setForm({ ...initialState, type: e.target.value });
+      const handleTravelModeChange = e => setForm(prev => ({ ...prev, travelMode: e.target.value, fields: {} }));
 
       const handleSubmit = e => {
         e.preventDefault();
@@ -136,8 +133,8 @@
         if (form.type === '出行') {
           return (
             <>
-              <div className="mt-4">
-                <label className="block mb-1 font-medium">出行方式</label>
+              <div className="space-y-2">
+                <label className="text-sm">出行方式</label>
                 <div className="flex flex-wrap gap-4">
                   {travelModes.map(m => (
                     <label key={m} className="flex items-center gap-2">
@@ -155,11 +152,11 @@
                 </div>
               </div>
               {form.travelMode && travelFieldMap[form.travelMode].map(f => (
-                <div key={f.name} className="mt-2">
-                  <label className="block text-sm font-medium mb-1">{f.label}</label>
+                <div key={f.name} className="space-y-1">
+                  <label className="text-sm">{f.label}</label>
                   <input
                     type={f.type || 'text'}
-                    className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#10a37f]"
+                    className="w-full bg-[#40414f] border border-gray-600 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#10a37f]"
                     value={form.fields[f.name] || ''}
                     onChange={e => handleFieldChange(f.name, e.target.value)}
                   />
@@ -168,39 +165,18 @@
             </>
           );
         }
-        if (form.type === '酒店') {
-          return hotelFields.map(f => (
-            <div key={f.name} className="mt-2">
-              <label className="block text-sm font-medium mb-1">{f.label}</label>
+        const maps = {
+          '酒店': hotelFields,
+          '餐厅': restaurantFields,
+          '活动地点': activityFields
+        }[form.type];
+        if (maps) {
+          return maps.map(f => (
+            <div key={f.name} className="space-y-1">
+              <label className="text-sm">{f.label}</label>
               <input
                 type={f.type || 'text'}
-                className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#10a37f]"
-                value={form.fields[f.name] || ''}
-                onChange={e => handleFieldChange(f.name, e.target.value)}
-              />
-            </div>
-          ));
-        }
-        if (form.type === '餐厅') {
-          return restaurantFields.map(f => (
-            <div key={f.name} className="mt-2">
-              <label className="block text-sm font-medium mb-1">{f.label}</label>
-              <input
-                type={f.type || 'text'}
-                className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#10a37f]"
-                value={form.fields[f.name] || ''}
-                onChange={e => handleFieldChange(f.name, e.target.value)}
-              />
-            </div>
-          ));
-        }
-        if (form.type === '活动地点') {
-          return activityFields.map(f => (
-            <div key={f.name} className="mt-2">
-              <label className="block text-sm font-medium mb-1">{f.label}</label>
-              <input
-                type={f.type || 'text'}
-                className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#10a37f]"
+                className="w-full bg-[#40414f] border border-gray-600 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#10a37f]"
                 value={form.fields[f.name] || ''}
                 onChange={e => handleFieldChange(f.name, e.target.value)}
               />
@@ -211,63 +187,80 @@
       };
 
       return (
-        <form onSubmit={handleSubmit} className="bg-white rounded border border-gray-200 shadow-sm p-4">
-          <div>
-            <label className="block text-sm font-medium mb-1">事项类型</label>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1">
+            <label className="text-sm">事项类型</label>
             <select
               value={form.type}
               onChange={handleTypeChange}
-              className="w-full border border-gray-300 rounded px-3 py-2 bg-white focus:outline-none focus:ring-2 focus:ring-[#10a37f]"
+              className="w-full bg-[#40414f] border border-gray-600 rounded px-3 py-2"
             >
               {typeOptions.map(t => (
                 <option key={t} value={t}>{t}</option>
               ))}
             </select>
           </div>
-          <div className="mt-4">
-            <label className="block text-sm font-medium mb-1">事项名称</label>
+          <div className="space-y-1">
+            <label className="text-sm">事项名称</label>
             <input
               type="text"
-              className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#10a37f]"
+              className="w-full bg-[#40414f] border border-gray-600 rounded px-3 py-2"
               value={form.name}
               onChange={e => handleChange('name', e.target.value)}
               required
             />
           </div>
-          <div className="mt-4">
-            <label className="block text-sm font-medium mb-1">预计所需时间（分钟）</label>
+          <div className="space-y-1">
+            <label className="text-sm">预计所需时间（分钟）</label>
             <input
               type="number"
-              className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#10a37f]"
+              className="w-full bg-[#40414f] border border-gray-600 rounded px-3 py-2"
               value={form.duration}
               onChange={e => handleChange('duration', e.target.value)}
             />
           </div>
-          <div className="mt-4">
-            <label className="block text-sm font-medium mb-1">外链</label>
-            <div className="flex flex-col gap-2">
+          <div className="space-y-1">
+            <label className="text-sm">外链</label>
+            <div className="space-y-2">
               <div className="flex items-center gap-2">
                 <img src={linkIcons.gaode} alt="gaode" className="w-5 h-5" />
-                <input type="url" placeholder="高德" className="flex-1 border rounded px-2 py-1" value={form.links.gaode} onChange={e => handleLinkChange('gaode', e.target.value)} />
+                <input
+                  type="url"
+                  placeholder="高德"
+                  className="flex-1 bg-[#40414f] border border-gray-600 rounded px-2 py-1"
+                  value={form.links.gaode}
+                  onChange={e => handleLinkChange('gaode', e.target.value)}
+                />
               </div>
               <div className="flex items-center gap-2">
                 <img src={linkIcons.xhs} alt="xhs" className="w-5 h-5" />
-                <input type="url" placeholder="小红书" className="flex-1 border rounded px-2 py-1" value={form.links.xhs} onChange={e => handleLinkChange('xhs', e.target.value)} />
+                <input
+                  type="url"
+                  placeholder="小红书"
+                  className="flex-1 bg-[#40414f] border border-gray-600 rounded px-2 py-1"
+                  value={form.links.xhs}
+                  onChange={e => handleLinkChange('xhs', e.target.value)}
+                />
               </div>
               <div className="flex items-center gap-2">
                 <img src={linkIcons.meituan} alt="meituan" className="w-5 h-5" />
-                <input type="url" placeholder="美团" className="flex-1 border rounded px-2 py-1" value={form.links.meituan} onChange={e => handleLinkChange('meituan', e.target.value)} />
+                <input
+                  type="url"
+                  placeholder="美团"
+                  className="flex-1 bg-[#40414f] border border-gray-600 rounded px-2 py-1"
+                  value={form.links.meituan}
+                  onChange={e => handleLinkChange('meituan', e.target.value)}
+                />
               </div>
             </div>
           </div>
           {renderDynamicFields()}
-          <button type="submit" className="mt-4 px-4 py-2 bg-[#10a37f] hover:bg-[#0e8c68] text-white rounded">生成卡片</button>
+          <button type="submit" className="w-full py-2 bg-[#10a37f] rounded text-white">保存</button>
         </form>
       );
     }
 
     function Card({ data, onDelete }) {
-      const [open, setOpen] = useState(false);
       const typeIcons = {
         '出发地': '📍',
         '出行': '🚗',
@@ -276,59 +269,62 @@
         '活动地点': '🎉'
       };
       return (
-        <div className="bg-white rounded border border-gray-200 shadow-sm">
-          <div className="flex justify-between items-center p-4 cursor-pointer" onClick={() => setOpen(!open)}>
-            <div className="flex items-center gap-2">
-              <span>{typeIcons[data.type]}</span>
+        <div className="flex gap-3">
+          <div className="w-8 h-8 rounded-full bg-[#10a37f] flex items-center justify-center text-white flex-shrink-0">
+            {typeIcons[data.type]}
+          </div>
+          <div className="flex-1 bg-[#40414f] rounded-lg p-4 space-y-2">
+            <div className="flex justify-between items-center">
               <h3 className="font-semibold">{data.name}</h3>
+              <button className="text-red-400 text-sm" onClick={() => onDelete(data.id)}>删除</button>
             </div>
-            <div className="flex items-center gap-2">
-              {data.duration && <span className="text-sm text-gray-500">{data.duration} 分钟</span>}
-              <button className="text-red-500" onClick={e => { e.stopPropagation(); onDelete(data.id); }}>删除</button>
+            {data.duration && <div className="text-sm text-gray-400">{data.duration} 分钟</div>}
+            {data.travelMode && <div className="text-sm">出行方式：{data.travelMode}</div>}
+            {data.details.map((d, i) => (
+              <div key={i} className="text-sm">{d.label}：{d.value}</div>
+            ))}
+            <div className="flex gap-2 pt-2">
+              {Object.entries(data.links).map(([key, url]) => (
+                url ? (
+                  <a key={key} href={url} target="_blank" rel="noopener noreferrer">
+                    <img src={linkIcons[key]} alt={key} className="w-5 h-5" />
+                  </a>
+                ) : null
+              ))}
             </div>
           </div>
-          {open && (
-            <div className="border-t p-4 space-y-2">
-              {data.travelMode && <div>出行方式：{data.travelMode}</div>}
-              {data.details.map((d, i) => (
-                <div key={i}>{d.label}：{d.value}</div>
-              ))}
-              <div className="flex gap-2 pt-2">
-                {Object.entries(data.links).map(([key, url]) => (
-                  url ? (
-                    <a key={key} href={url} target="_blank" rel="noopener noreferrer">
-                      <img src={linkIcons[key]} alt={key} className="w-6 h-6" />
-                    </a>
-                  ) : null
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      );
-    }
-
-    function Timeline({ items, onDelete }) {
-      return (
-        <div className="mt-6 space-y-4">
-          {items.map(item => (
-            <Card key={item.id} data={item} onDelete={onDelete} />
-          ))}
         </div>
       );
     }
 
     function App() {
       const [cards, setCards] = useState([]);
+      const [open, setOpen] = useState(false);
 
       const addCard = card => setCards(prev => [...prev, card]);
       const deleteCard = id => setCards(prev => prev.filter(c => c.id !== id));
 
       return (
-        <div className="max-w-2xl mx-auto">
-          <h1 className="text-3xl font-bold text-center mb-6 text-[#10a37f]">出行计划</h1>
-          <TravelForm onAdd={addCard} />
-          <Timeline items={cards} onDelete={deleteCard} />
+        <div className="flex flex-col h-full">
+          <header className="bg-[#202123] p-4 text-center text-[#10a37f] font-bold">旅行计划</header>
+          <main className="flex-1 overflow-y-auto p-4 space-y-4">
+            {cards.map(card => (
+              <Card key={card.id} data={card} onDelete={deleteCard} />
+            ))}
+          </main>
+          <div className="p-4 bg-[#40414f]">
+            <button
+              onClick={() => setOpen(true)}
+              className="w-full py-2 px-3 rounded-md bg-[#10a37f] text-white"
+            >
+              新增事项
+            </button>
+          </div>
+          {open && (
+            <Modal onClose={() => setOpen(false)}>
+              <TravelForm onAdd={card => { addCard(card); setOpen(false); }} />
+            </Modal>
+          )}
         </div>
       );
     }


### PR DESCRIPTION
## Summary
- overhaul interface to a ChatGPT-inspired dark theme
- add modal-based travel item form and chat-style timeline cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7b42c27508332b38a1bf2ce787256